### PR TITLE
Add support for project wide properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,25 @@ No additional setup is required, since it uses the React Native's default Geoloc
     }
     ```
 
-    If you have a different play service version than the one included in this library, use the following instead. But play service version should be `11+` or the library won't work.
+    If you've defined [project-wide properties](https://developer.android.com/studio/build/gradle-tips#configure-project-wide-properties) (recommended) in your root build.gradle, this library will detect the presence of the following properties:
+
+    ```gradle
+    buildscript {...}
+    allprojects {...}
+
+    /**
+     + Project-wide Gradle configuration properties
+     */
+    ext {
+        compileSdkVersion   = 25
+        targetSdkVersion    = 25
+        buildToolsVersion   = "25.0.2"
+        supportLibVersion   = "25.0.1"
+        googlePlayServicesVersion = "11.0.0"
+    }
+    ```
+
+    If you do not have *project-wide properties* defined and have a different play-services version than the one included in this library, use the following instead. But play service version should be `11+` or the library won't work.
 
     ```gradle
     ...

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,18 @@
 apply plugin: 'com.android.library'
 
+def DEFAULT_COMPILE_SDK_VERSION             = 25
+def DEFAULT_BUILD_TOOLS_VERSION             = "25.0.2"
+def DEFAULT_TARGET_SDK_VERSION              = 25
+def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION    = "11.0.0"
+def DEFAULT_SUPPORT_LIB_VERSION             = "25.0.1"
+
 android {
-    compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
+    buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion rootProject.hasProperty('targetSdkVersion') ? rootProject.targetSdkVersion : DEFAULT_TARGET_SDK_VERSION
     }
 
     lintOptions {
@@ -15,7 +21,10 @@ android {
 }
 
 dependencies {
+    def googlePlayServicesVersion = rootProject.hasProperty('googlePlayServicesVersion') ? rootProject.googlePlayServicesVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
+    def supportLibVersion = rootProject.hasProperty('supportLibVersion') ? rootProject.supportLibVersion : DEFAULT_SUPPORT_LIB_VERSION
+
     provided "com.facebook.react:react-native:+"
-    compile "com.android.support:appcompat-v7:25.0.1"
-    compile "com.google.android.gms:play-services-location:11.0.0"
+    compile "com.android.support:appcompat-v7:$supportLibVersion"
+    compile "com.google.android.gms:play-services-location:$googlePlayServicesVersion"
 }


### PR DESCRIPTION
Thought would be interesting to support [project wide properties](https://developer.android.com/studio/build/gradle-tips#configure-project-wide-properties) to make it a bit easier to install and customize versions. The idea was from react-maps-native package :D