### PR TITLE
added forceRequestLocation flag and detect no No location provider available

### DIFF
--- a/android/src/main/java/com/agontuk/RNFusedLocation/LocationUtils.java
+++ b/android/src/main/java/com/agontuk/RNFusedLocation/LocationUtils.java
@@ -5,6 +5,8 @@ import android.content.pm.PackageManager;
 import android.location.Location;
 import android.Manifest;
 import android.os.Build;
+import android.text.TextUtils;
+import android.provider.Settings;
 import android.support.v4.app.ActivityCompat;
 
 import com.facebook.react.bridge.Arguments;
@@ -20,6 +22,28 @@ public class LocationUtils {
     public static boolean hasLocationPermission(Context context) {
         return ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED ||
             ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED;
+    }
+
+    /**
+     * Check if location is enabled on the device.
+     */
+    public static boolean isLocationEnabled(Context context) {
+        int locationMode = 0;
+        String locationProviders;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            try {
+                locationMode = Settings.Secure.getInt(context.getContentResolver(), Settings.Secure.LOCATION_MODE);
+            } catch (Settings.SettingNotFoundException e) {
+                return false;
+            }
+
+            return locationMode != Settings.Secure.LOCATION_MODE_OFF;
+
+        } else {
+            locationProviders = Settings.Secure.getString(context.getContentResolver(), Settings.Secure.LOCATION_PROVIDERS_ALLOWED);
+            return !TextUtils.isEmpty(locationProviders);
+        }
     }
 
     /**

--- a/android/src/main/java/com/agontuk/RNFusedLocation/RNFusedLocationModule.java
+++ b/android/src/main/java/com/agontuk/RNFusedLocation/RNFusedLocationModule.java
@@ -127,6 +127,15 @@ public class RNFusedLocationModule extends ReactContextBaseJavaModule {
             return;
         }
 
+        if (!LocationUtils.isLocationEnabled(context)) {
+            invokeError(
+                    LocationError.POSITION_UNAVAILABLE.getValue(),
+                    "No location provider available.",
+                    true
+            );
+            return;
+        }
+
         if (!LocationUtils.isGooglePlayServicesAvailable(context)) {
             invokeError(
                 LocationError.PLAY_SERVICE_NOT_AVAILABLE.getValue(),
@@ -185,6 +194,15 @@ public class RNFusedLocationModule extends ReactContextBaseJavaModule {
                 LocationError.PERMISSION_DENIED.getValue(),
                 "Location permission not granted.",
                 false
+            );
+            return;
+        }
+
+        if (!LocationUtils.isLocationEnabled(context)) {
+            invokeError(
+                    LocationError.POSITION_UNAVAILABLE.getValue(),
+                    "No location provider available.",
+                    false
             );
             return;
         }


### PR DESCRIPTION
In the case where "Improve Location accuracy" is Off on Android O+, it is still possible to use just the GPS to retrieve locations.

To cover those scenarios, I have added a flag to allow requesting a location even though the SETTINGS_NOT_SATISFIED error was raised.

That will allow trying to request a location even though the user has clicked "Deny" on the Improve Location Request modal.