### PR TITLE
Update typings based on @react-native-community/geolocation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,7 @@ declare module 'react-native-geolocation-service' {
     maximumAge?: number
     enableHighAccuracy?: boolean
     distanceFilter?: number
+    useSignificantChanges?: boolean
     showLocationDialog?: boolean,
     forceRequestLocation?: boolean
   }
@@ -35,22 +36,23 @@ declare module 'react-native-geolocation-service' {
   }
 
   export interface GeoCoordinates {
-    latitude?: number
-    longitude?: number
-    accuracy?: number
-    altitude?: number
-    heading?: number
-    speed?: number
-    altitudeAccuracy?: number
+    latitude: number
+    longitude: number
+    accuracy: number
+    altitude: number | null
+    heading: number | null
+    speed: number | null
+    altitudeAccuracy: number | null
   }
 
   export interface GeoPosition {
     coords: GeoCoordinates
-    timestamp: Date
+    timestamp: number
   }
 
   export interface GeoConfig {
-    skipPermissionRequests?: boolean
+    skipPermissionRequests: boolean
+    authorizationLevel: 'always' | 'whenInUse' | 'auto'
   }
 
   export function setRNConfiguration(config: GeoConfig): void


### PR DESCRIPTION
The Typescript types don't seem to currently properly match the ones from `@react-native-community/geolocation` library.

I have updated the types based on their typings file:
https://github.com/react-native-community/react-native-geolocation/blob/master/typings/index.d.ts


@Agontuk 