### PR TITLE
Add optional mocked field to GeoPosition type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -48,6 +48,7 @@ declare module 'react-native-geolocation-service' {
   export interface GeoPosition {
     coords: GeoCoordinates
     timestamp: number
+    mocked?: boolean;
   }
 
   export interface GeoConfig {


### PR DESCRIPTION
Closes issue #124.

Adds optional `mocked` field to `GeoPosition` type. 

This field exists on Android (SDK version >= 18), but not on iOS. 