### PR TITLE
Removed premature check of isLocationEnabled in startObserving()

### DIFF
--- a/android/src/main/java/com/agontuk/RNFusedLocation/RNFusedLocationModule.java
+++ b/android/src/main/java/com/agontuk/RNFusedLocation/RNFusedLocationModule.java
@@ -219,15 +219,6 @@ public class RNFusedLocationModule extends ReactContextBaseJavaModule {
             return;
         }
 
-        if (!LocationUtils.isLocationEnabled(context)) {
-            invokeError(
-                LocationError.POSITION_UNAVAILABLE.getValue(),
-                "No location provider available.",
-                false
-            );
-            return;
-        }
-
         if (!LocationUtils.isGooglePlayServicesAvailable(context)) {
             invokeError(
                 LocationError.PLAY_SERVICE_NOT_AVAILABLE.getValue(),


### PR DESCRIPTION
There was a fix added in 3.1.0 to address #108 , but it didn't include a fix for startObserving(), only getCurrentPoisition().