### PR TITLE
[iOS] Added permission getter and listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ When promise resolves, returns the status of the authorization.
 - `denied` - Permission denied
 - `restricted` - Permission restricted
 
+#### `async getCurrentAuthorization() (iOS only)`
+Get the current location permission status for the app without prompting the user for it.
+Possible return values are the same as for `requestAuthorization` and `null` can also be returned if no specific permission has been granted.
+
+#### `watchPermission(changedCallback) (iOS Only)`
+
+Subscribe to changes to the location permission. These can happen if the user changes them in the settings app while the app is running. `changedCallback` will be called with the authorization result (return values of `requestAuthorization`).
+
+**Returns**: A function to unsubscribe (remove the listener). If called `changedCallback` will stop receiving permission updates.
+
 #### `getCurrentPosition(successCallback, ?errorCallback, ?options)`
  - **successCallback**: Invoked with latest location info.
  - **errorCallback**: Invoked whenever an error is encountered.

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,8 +9,7 @@ declare module 'react-native-geolocation-service' {
     | 'nearestTenMeters'
     | 'hundredMeters'
     | 'kilometer'
-    | 'threeKilometers'
-    | 'reduced';
+    | 'threeKilometers';
 
   export type AccuracyAndroid =
     | 'high'
@@ -38,7 +37,6 @@ declare module 'react-native-geolocation-service' {
     interval?: number
     fastestInterval?: number
     useSignificantChanges?: boolean
-    showsBackgroundLocationIndicator?: boolean
   }
 
   export enum PositionError {
@@ -71,9 +69,13 @@ declare module 'react-native-geolocation-service' {
     mocked?: boolean;
   }
 
+  type PermissionChangedCallback = (permission: AuthorizationResult) => void
+
   type SuccessCallback = (position: GeoPosition) => void
 
   type ErrorCallback = (error: GeoError) => void
+
+  export function getCurrentAuthorization(): Promise<AuthorizationResult | null>
 
   export function requestAuthorization(
     authorizationLevel: AuthorizationLevel
@@ -84,6 +86,10 @@ declare module 'react-native-geolocation-service' {
     errorCallback?: ErrorCallback,
     options?: GeoOptions
   ): void
+
+  export function watchPermission(
+    changedCallback: PermissionChangedCallback
+  ): () => void
 
   export function watchPosition(
     successCallback: SuccessCallback,

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,7 +9,8 @@ declare module 'react-native-geolocation-service' {
     | 'nearestTenMeters'
     | 'hundredMeters'
     | 'kilometer'
-    | 'threeKilometers';
+    | 'threeKilometers'
+    | 'reduced';
 
   export type AccuracyAndroid =
     | 'high'
@@ -37,6 +38,7 @@ declare module 'react-native-geolocation-service' {
     interval?: number
     fastestInterval?: number
     useSignificantChanges?: boolean
+    showsBackgroundLocationIndicator?: boolean
   }
 
   export enum PositionError {

--- a/ios/RNFusedLocationBridge.m
+++ b/ios/RNFusedLocationBridge.m
@@ -4,6 +4,11 @@
 @interface RCT_EXTERN_MODULE(RNFusedLocation, RCTEventEmitter)
 
 RCT_EXTERN_METHOD(
+  getCurrentAuthorization:(RCTPromiseResolveBlock *)resolve
+                   reject:(RCTPromiseRejectBlock)reject
+)
+
+RCT_EXTERN_METHOD(
   requestAuthorization:(NSString *)level
                resolve:(RCTPromiseResolveBlock)resolve
                 reject:(RCTPromiseRejectBlock)reject
@@ -14,6 +19,10 @@ RCT_EXTERN_METHOD(
      successCallback:(RCTResponseSenderBlock)successCallback
        errorCallback:(RCTResponseSenderBlock)errorCallback
 )
+
+RCT_EXTERN_METHOD(permissionListenerAdded)
+
+RCT_EXTERN_METHOD(permissionListenerRemoved)
 
 _RCT_EXTERN_REMAP_METHOD(
   startObserving,

--- a/js/Geolocation.js
+++ b/js/Geolocation.js
@@ -20,6 +20,10 @@ const Geolocation = {
     navigator.geolocation.getCurrentPosition(success, error, options);
   },
 
+  watchPermission: function () {
+    throw new Error('Method not supported by browser')
+  },
+
   watchPosition: function (success, error, options) {
     if (!success) {
       throw new Error('Must provide a success callback');

--- a/js/Geolocation.js
+++ b/js/Geolocation.js
@@ -6,6 +6,10 @@ const Geolocation = {
     throw new Error('Method not supported by browser');
   },
 
+  getCurrentAuthorization: function () {
+    throw new Error('Method not supported by browser');
+  },
+
   requestAuthorization: async function () {
     return Promise.reject('Method not supported by browser');
   },

--- a/js/Geolocation.native.js
+++ b/js/Geolocation.native.js
@@ -10,6 +10,14 @@ let updatesEnabled = false;
 const Geolocation = {
   setRNConfiguration: (config) => {}, // eslint-disable-line no-unused-vars
 
+  getCurrentAuthorization: async () => {
+    if (Platform.OS !== 'ios') {
+      Promise.reject('getCurrentAuthorization is only for iOS');
+    }
+
+    return RNFusedLocation.getCurrentAuthorization();
+  },
+
   requestAuthorization: async (authorizationLevel) => {
     if (Platform.OS !== 'ios') {
       return Promise.reject('requestAuthorization is only for iOS');
@@ -31,6 +39,22 @@ const Geolocation = {
 
     // Right now, we're assuming user already granted location permission.
     RNFusedLocation.getCurrentPosition(options, success, error);
+  },
+
+  watchPermission: (changed) => {
+    if (Platform.OS !== 'ios') {
+      throw new Error('watchPermission is only for iOS');
+    }
+    if (!changed) {
+      throw new Error('Must provide a changed callback');
+    }
+
+    const subscription = LocationEventEmitter.addListener('geolocationPermissionDidChange', changed);
+    RNFusedLocation.permissionListenerAdded();
+    return () => {
+      RNFusedLocation.permissionListenerRemoved();
+      subscription.remove();
+    };
   },
 
   watchPosition: (success, error = null, options = {}) => {

--- a/js/Geolocation.native.js
+++ b/js/Geolocation.native.js
@@ -10,9 +10,9 @@ let updatesEnabled = false;
 const Geolocation = {
   setRNConfiguration: (config) => {}, // eslint-disable-line no-unused-vars
 
-  getCurrentAuthorization: async () => {
+  getCurrentAuthorization: () => {
     if (Platform.OS !== 'ios') {
-      Promise.reject('getCurrentAuthorization is only for iOS');
+      return Promise.reject('getCurrentAuthorization is only for iOS');
     }
 
     return RNFusedLocation.getCurrentAuthorization();


### PR DESCRIPTION
- Added `getCurrentAuthorization` in iOS to get the current authorization status
- Added `watchPermission` in iOS to listen to changes to the permission status of the app

Tested in the simulator and added to our next production release with `patch-package`.