### PR TITLE
Add location extras support

### DIFF
--- a/android/src/main/java/com/agontuk/RNFusedLocation/LocationUtils.java
+++ b/android/src/main/java/com/agontuk/RNFusedLocation/LocationUtils.java
@@ -137,6 +137,16 @@ public class LocationUtils {
       map.putBoolean("mocked", location.isFromMockProvider());
     }
 
+    Bundle bundle = location.getExtras();
+    if (bundle != null) {
+      WritableMap extras = Arguments.createMap();
+      for (String key: bundle.keySet()) {
+        putIntoMap(extras, key, bundle.get(key));
+      }
+
+      map.putMap("extras", extras);
+    }
+
     return map;
   }
 


### PR DESCRIPTION
Android
- Add support for retrieving provider additional information.

Reference
https://developer.android.com/reference/android/location/Location#getExtras()

TEST
- Tested using a Trimble R10 GPS receiver and Trimble mobile manager mock location.