### PR TITLE
maxAge nanosecond conversion fix, fixes #266

### DIFF
--- a/android/src/main/java/com/agontuk/RNFusedLocation/LocationUtils.java
+++ b/android/src/main/java/com/agontuk/RNFusedLocation/LocationUtils.java
@@ -26,7 +26,7 @@ public class LocationUtils {
    */
   public static long getLocationAge(Location location) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
-      return (SystemClock.elapsedRealtimeNanos() - location.getElapsedRealtimeNanos()) / 1000000;
+      return (SystemClock.elapsedRealtimeNanos() - location.getElapsedRealtimeNanos()) / 1000;
     }
 
     return System.currentTimeMillis() - location.getTime();


### PR DESCRIPTION
maxAge was in seconds instead of miliseconds

Conversion of nanoseconds to miliseconds fixed. 
it was being converted to seconds instead of milis but only for some API versions