### PR TITLE
Catch RuntimeException raised when calling invoke more than once on the same callback

### DIFF
--- a/android/src/main/java/com/agontuk/RNFusedLocation/RNFusedLocationModule.java
+++ b/android/src/main/java/com/agontuk/RNFusedLocation/RNFusedLocationModule.java
@@ -68,7 +68,11 @@ public class RNFusedLocationModule extends ReactContextBaseJavaModule implements
     ReactApplicationContext context = getContext();
 
     if (!LocationUtils.hasLocationPermission(context)) {
-      error.invoke(LocationUtils.buildError(LocationError.PERMISSION_DENIED, null));
+      try {
+        error.invoke(LocationUtils.buildError(LocationError.PERMISSION_DENIED, null));
+      } catch (RuntimeException e) {
+        Log.w(TAG, e.getMessage());
+      }
       return;
     }
 
@@ -82,13 +86,21 @@ public class RNFusedLocationModule extends ReactContextBaseJavaModule implements
     locationProvider.getCurrentLocation(locationOptions, new LocationChangeListener() {
       @Override
       public void onLocationChange(Location location) {
-        success.invoke(LocationUtils.locationToMap(location));
+        try {
+          success.invoke(LocationUtils.locationToMap(location));
+        } catch (RuntimeException e) {
+          Log.w(TAG, e.getMessage());
+        }
         singleLocationProviders.remove(key);
       }
 
       @Override
       public void onLocationError(LocationError locationError, @Nullable String message) {
-        error.invoke(LocationUtils.buildError(locationError, message));
+        try {
+          error.invoke(LocationUtils.buildError(locationError, message));
+        } catch (RuntimeException e) {
+          Log.w(TAG, e.getMessage());
+        }
         singleLocationProviders.remove(key);
       }
     });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary
Catch `RuntimeException` raised when calling `invoke` more than once on the same callback
<!-- What existing problem does the pull request solve? -->
Fixes crashes when several requests are made simultaneously
## Test Plan
Tested in production with current code, over ~2500 users, no changes in existing behavior, no crashes either
<!-- Demonstrate how you have verified that your changes work. -->
