### PR TITLE
iOS Crash fix due to race conditions

### DIFF
--- a/ios/LocationProvider.swift
+++ b/ios/LocationProvider.swift
@@ -37,8 +37,8 @@ class LocationProvider: NSObject {
   }
 
   func getCurrentLocation(_ options: LocationOptions) -> Void {
-    if locationManager.location != nil {
-      let elapsedTime = (Date().timeIntervalSince1970 - locationManager.location!.timestamp.timeIntervalSince1970) * 1000
+    if let location = locationManager.location {
+      let elapsedTime = (Date().timeIntervalSince1970 - location.timestamp.timeIntervalSince1970) * 1000
 
       #if DEBUG
         NSLog("RNLocation: elapsedTime=\(elapsedTime)ms, maxAge=\(options.maximumAge)ms")
@@ -48,7 +48,7 @@ class LocationProvider: NSObject {
         #if DEBUG
           NSLog("RNLocation: returning cached location")
         #endif
-        delegate?.onLocationChange(self, location: locationManager.location!)
+        delegate?.onLocationChange(self, location: location)
         return
       }
     }


### PR DESCRIPTION
## Summary
Make sure to keep a copy of the unwrapped variable in case it is nulled out in between.

Solves https://github.com/Agontuk/react-native-geolocation-service/issues/369

## Test Plan
Test on real device (iPhone 12 pro). More info on linked issue.
