### PR TITLE
remove buildToolsVersion config

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'com.android.library'
 
 def DEFAULT_COMPILE_SDK_VERSION          = 29
-def DEFAULT_BUILD_TOOLS_VERSION          = "29.0.2"
 def DEFAULT_MIN_SDK_VERSION              = 16
 def DEFAULT_TARGET_SDK_VERSION           = 29
 def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION = "18.0.0"
@@ -12,7 +11,6 @@ def safeExtGet(prop, fallback) {
 
 android {
   compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
-  buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
 
   defaultConfig {
     minSdkVersion safeExtGet('minSdkVersion', DEFAULT_MIN_SDK_VERSION)


### PR DESCRIPTION
## Summary

buildToolsVersion is no longer required since AGP 3.1 (March 2018), See https://developer.android.com/studio/releases/gradle-plugin#3-1-0. Having buildToolsVersion is extra noise and download for no value

## Test Plan

The module will build and work as before.