### PR TITLE
Note iOS compatability issues due to Swift implementation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ npm install react-native-geolocation-service
 | <0.60      | 2.0.0           |
 | <0.57      | 1.1.0           |
 
+
+| iOS Version |
+|-------------|
+| 13+         |
+
+Using this package at iOS 12  causes the app to crash on open due to lack of Swift support.
+
 # Setup
  - See [docs/setup.md](docs/setup.md)
  - Check out example project


### PR DESCRIPTION
## Summary

Documentation does not indicate that this library will cause apps to crash on open at iOS 12.
This is due to it's reliance on Swift which is not available until iOS 13.
iOS 12 is still widely used and supported to RN <= 0.72
This addresses issue #430

## Test Plan

Documentation change only.