### PR TITLE
Update setup.md - adding playServicesLocationVersion

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -50,15 +50,13 @@ For RN 0.60 or higher, no manual linking is needed. You can override following g
 
 ```gradle
 ext {
-  compileSdkVersion   = 28
-  buildToolsVersion   = "28.0.3"
-  minSdkVersion       = 16
-  targetSdkVersion    = 28
+  compileSdkVersion   = 34
+  buildToolsVersion   = "34.0.0"
+  minSdkVersion       = 21
+  targetSdkVersion    = 34
 
-  // Any of the following will work
-  googlePlayServicesVersion      = "17.0.0"
-  // playServicesVersion         = "17.0.0"
-  // playServicesLocationVersion = "17.0.0"
+  //Add the following line 
+  playServicesLocationVersion = "21.0.1"
 }
 ```
 


### PR DESCRIPTION
The setup instructions suggest adding `googlePlayServicesVersion`, `playServicesVersion` or `playServicesLocationVersion` to the `android/build.gradle` file. 
Only using the last one `playServicesLocationVersion` works. The other 2 throw dependency errors. 

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. -->

## Summary
1. I updated the version numbers referenced in the setup instructions for the `android/build.gradle` file. 
2. Adding `googlePlayServicesVersion` or `playServicesVersion` throws an error while using `playServicesLocationVersion` works.

<!-- What existing problem does the pull request solve? -->
#398 
## Test Plan

<!-- Demonstrate how you have verified that your changes work. -->
I tried using `googlePlayServicesVersion` and using `playServicesVersion`. In both scenarios, building the app (by executing `npx react-native run-android`) throws an error regarding dependencies. I used `playServicesLocationVersion`. The app was built successfully, and the current location was picked correctly.