### PR TITLE
setup namespace

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,6 +11,8 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
+  namespace "com.agontuk.RNFusedLocation"
+
   compileSdkVersion safeExtGet('compileSdkVersion', DEFAULT_COMPILE_SDK_VERSION)
   buildToolsVersion safeExtGet('buildToolsVersion', DEFAULT_BUILD_TOOLS_VERSION)
 


### PR DESCRIPTION
## Summary

This pull request resolves the issue with the react-native-geolocation-service module failing to build due to a missing namespace in the module's build.gradle file.

`
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring project ':react-native-geolocation-service'.
> Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.
   > Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

`

## Test Plan

Build successfully on Gradle > 8.0.1